### PR TITLE
Set default (selected) option for <select> tag

### DIFF
--- a/swal-forms.js
+++ b/swal-forms.js
@@ -219,7 +219,8 @@
         return inputTag + labelTag
 
         function toHtmlOptions (optionsString, option) {
-          return optionsString + t("<option value='{value}'>{text}</option>", option)
+            option.selected = ((typeof option.selected !== 'undefined') && option.selected) ? ' selected' : ''
+            return optionsString + t("<option value='{value}' {selected}>{text}</option>", option)
         }
       }
     }

--- a/swal-forms.js
+++ b/swal-forms.js
@@ -219,7 +219,7 @@
         return inputTag + labelTag
 
         function toHtmlOptions (optionsString, option) {
-            option.selected = ((typeof option.selected !== 'undefined') && option.selected) ? ' selected' : ''
+            option.selected = option.selected ? ' selected' : ''
             return optionsString + t("<option value='{value}'{selected}>{text}</option>", option)
         }
       }

--- a/swal-forms.js
+++ b/swal-forms.js
@@ -220,7 +220,7 @@
 
         function toHtmlOptions (optionsString, option) {
             option.selected = ((typeof option.selected !== 'undefined') && option.selected) ? ' selected' : ''
-            return optionsString + t("<option value='{value}' {selected}>{text}</option>", option)
+            return optionsString + t("<option value='{value}'{selected}>{text}</option>", option)
         }
       }
     }


### PR DESCRIPTION
Allows to set the default value for option in the select, when the form is created, by adding `selected:true` property, for example `{value: '3', text: 'test3', selected: true}`